### PR TITLE
Fix build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,17 +2,29 @@ use nasm_rs;
 use std::env;
 
 fn main() {
-    if env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "unix" {
-		if let Err(e) = nasm_rs::compile_library_args("libunix_main.a", &["src/unix_main.asm"], &["-Psrc/sprites.inc", "-f elf64"]) {
-			// TODO: add better error handling
-			panic!("{}", e);
-		}
-		
+    if env::var("CARGO_CFG_UNIX").is_ok() {
+        if let Err(e) = nasm_rs::compile_library_args(
+            "libunix_main.a",
+            &["src/unix_main.asm"],
+            &["-Psrc/sprites.inc", "-f elf64"],
+        ) {
+            // TODO: add better error handling
+            panic!("{}", e);
+        }
+    } else if env::var("CARGO_CFG_WINDOWS").is_ok() {
+        println!("cargo:rustc-link-lib=static=windows_main");
+        if let Err(e) = nasm_rs::compile_library_args(
+            "windows_main.lib",
+            &["src/windows_main.asm"],
+            &["-Psrc/sprites.inc", "-f win64"],
+        ) {
+            // TODO: add better error handling
+            panic!("{}", e);
+        }
     } else {
-		println!("cargo:rustc-link-lib=static=windows_main");
-        if let Err(e) = nasm_rs::compile_library_args("windows_main.lib", &["src/windows_main.asm"], &["-Psrc/sprites.inc", "-f win64"]) {
-			// TODO: add better error handling
-			panic!("{}", e);
-		}
+        panic!(
+            "hit or miss? i guess {} never miss, huh?",
+            env::var("CARGO_CFG_TARGET_OS").unwrap_or("they".into())
+        )
     }
 }


### PR DESCRIPTION
It is permitted for `CARGO_CFG_TARGET_FAMILY` to return a string that indicates multiple values, because it in fact is *all* the families of that target.

The script is slightly simpler if it just uses `CARGO_CFG_UNIX` and `CARGO_CFG_WINDOWS`.